### PR TITLE
BUGFIX: Fixed referenced stack variable returned from function in constructHexagon

### DIFF
--- a/Assignments/P1 - Path Planner/Source/Framework/PathPlannerApp/PathPlannerLab.cpp
+++ b/Assignments/P1 - Path Planner/Source/Framework/PathPlannerApp/PathPlannerLab.cpp
@@ -86,9 +86,7 @@ void setBounds(double const h_radius, int const row_count, int const column_coun
 	}
 }
 
-POINT* constructHexagon(double const radius, POINT const& offset) {
-	POINT hexagon[6];
-
+POINT* constructHexagon(double const radius, POINT const& offset, POINT* hexagon) {
 	hexagon[0].x = hexagon[3].x = 0;
 	hexagon[4].x = hexagon[5].x = -(hexagon[1].x = hexagon[2].x = static_cast<LONG>(radius));
 
@@ -132,7 +130,8 @@ void drawTileHighlight(Tile const* tile, POINT const& offset, double const radiu
 	// Default = 30/radius + 1.05*radius
 	double const calculated_new_radius = ((radius_multiplier * 30) / radius) + ((radius_multiplier * 1.05) * radius);
 
-	POINT* end_point_hexagon = constructHexagon(calculated_new_radius, offset);
+	POINT end_point_hexagon[6];
+	constructHexagon(calculated_new_radius, offset, end_point_hexagon);
 	HRGN end_point_hex_region = CreatePolygonRgn(end_point_hexagon, 6, WINDING);
 
 	if (OffsetRgn(end_point_hex_region, x_offset, y_offset) != ERROR) {
@@ -145,7 +144,8 @@ void drawTileHighlight(Tile const* tile, POINT const& offset, double const radiu
 void drawGrid(TileMap const& tile_map, POINT const& offset, int grid_width, int grid_height, HDC device_context_handle)
 {
 	double const radius = tile_map.getTileRadius();
-	POINT* hexagon = constructHexagon(radius, offset);
+	POINT hexagon[6];
+	constructHexagon(radius, offset, hexagon);
 
 	if (HRGN hex_region = CreatePolygonRgn(hexagon, 6, WINDING))
 	{


### PR DESCRIPTION
In the function constructHexagon an array is constructed on the stack and later returned as a pointer.
This means the caller is uses an a stale reference and there is guarantee that the referenced position on the stack won't be overwritten at a later time or overwritten.

Unfortunately this bug does not present itself on Windows. This likely due to the fact that the stack frame in the calling function has already ready been setup and does not overwrite the hexagon.
While cross-compiling on Linux I came across this bug and it likely manifests as a difference in stack frame allocation or as a safety feature of Linux.

Either way this PR is a simple fix to the error.
We use a common C pattern of requiring the caller to pass in the block of memory to be modified. This way the scope of the hexagon will be properly preserved over its lifetime. 